### PR TITLE
Add RouterBase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is a collection of high-quality Orkas agents and skills, continuous
 Orkas homepage: https://orkas.ai?source=github<br>
 Orkas open-source version: https://github.com/Orkas-AI/Orkas
 
-Current catalog: 26 agents and 45 skills.
+Current catalog: 26 agents and 48 skills.
 
 ## Category Overview
 
@@ -17,7 +17,7 @@ Current catalog: 26 agents and 45 skills.
 | --- | --- | ---: | ---: | --- |
 | [Education](#education) | `education/` | 6 | 8 | Teaching, tutoring, lesson planning, quizzes, and learning materials. |
 | [E-commerce](#e-commerce) | `ecommerce/` | 3 | 4 | Product listings, customer support, campaign planning, and store operations. |
-| [Product and Engineering](#product-and-engineering) | `product/` | 6 | 12 | PRDs, technical specs, user stories, release notes, and research workflows. |
+| [Product and Engineering](#product-and-engineering) | `product/` | 6 | 15 | PRDs, technical specs, user stories, release notes, and research workflows. |
 | [Creation](#creation) | `creation/` | 3 | 8 | Creative direction, drafting, editing, rewriting, visual concepting, and publishing workflows. |
 | [Data](#data) | `data/` | 4 | 6 | Data cleaning, spreadsheet analysis, SQL reasoning, metrics, and reports. |
 | [Office](#office) | `office/` | 4 | 7 | Documents, slides, meeting notes, email drafts, and daily productivity. |
@@ -271,6 +271,18 @@ Current catalog: 26 agents and 45 skills.
     <tr>
       <td width="220" nowrap><a href="product/skills/product-ui/"><strong>product-ui</strong></a></td>
       <td>Use to design and implement product UI from PRD, product goals, user flows, or existing app context.</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="product/skills/routerbase-api-integration/"><strong>routerbase-api-integration</strong></a></td>
+      <td>Integrate applications with <a href="https://routerbase.com/">routerbase</a> as an OpenAI-compatible model gateway, including SDK migration, base URL setup, streaming, tool calling, JSON mode, and safe API key handling.</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="product/skills/routerbase-model-routing/"><strong>routerbase-model-routing</strong></a></td>
+      <td>Plan <a href="https://routerbase.com/">routerbase</a> model selection, fallback chains, cost-aware policies, latency budgets, and rollout validation for AI agent workflows.</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="product/skills/routerbase-media-generation/"><strong>routerbase-media-generation</strong></a></td>
+      <td>Build <a href="https://routerbase.com/">routerbase</a> image, audio, speech, and video generation workflows with endpoint selection, retries, polling, asset handling, and safety checks.</td>
     </tr>
     <tr>
       <td width="220" nowrap><a href="product/skills/skill-quality-tester/"><strong>skill-quality-tester</strong></a></td>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 Orkas 主页：https://orkas.ai?source=github<br>
 Orkas 开源版本：https://github.com/Orkas-AI/Orkas
 
-当前目录包含：26 个 agent，45 个 skill。
+当前目录包含：26 个 agent，48 个 skill。
 
 ## 分类总览
 
@@ -17,7 +17,7 @@ Orkas 开源版本：https://github.com/Orkas-AI/Orkas
 | --- | --- | ---: | ---: | --- |
 | [教育](#教育) | `education/` | 6 | 8 | 教学、辅导、教案、题目生成、学习材料等。 |
 | [电商](#电商) | `ecommerce/` | 3 | 4 | 商品详情、客服话术、活动策划、店铺运营等。 |
-| [产研](#产研) | `product/` | 6 | 12 | PRD、技术方案、用户故事、发布说明、需求研究等。 |
+| [产研](#产研) | `product/` | 6 | 15 | PRD、技术方案、用户故事、发布说明、需求研究等。 |
 | [创作](#创作) | `creation/` | 3 | 8 | 创意策划、起草、润色、改写、视觉构思、发布流程等。 |
 | [数据](#数据) | `data/` | 4 | 6 | 数据清洗、表格分析、SQL 推理、指标解读、数据报告等。 |
 | [办公](#办公) | `office/` | 4 | 7 | 文档、幻灯片、会议纪要、邮件草稿、日常效率等。 |
@@ -271,6 +271,18 @@ Orkas 开源版本：https://github.com/Orkas-AI/Orkas
     <tr>
       <td width="220" nowrap><a href="product/skills/product-ui/"><strong>product-ui</strong></a></td>
       <td>用于根据 PRD、产品目标、用户流程或现有应用上下文设计并实现产品 UI；适合&quot;做这个功能的界面&quot;&quot;实现一个前端页面&quot;&quot;把 PRD 转成 UI&quot;&quot;做一个像 Stripe/Linear/Vercel 的界面&quot;&quot;优化布局、组件、响应式和 A11y&quot;；触发词：产品UI、UI实现、前端界面、页面设计、组件设计、设计系统、品牌风格、响应式、A11y、视觉优化</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="product/skills/routerbase-api-integration/"><strong>routerbase-api-integration</strong></a></td>
+      <td>将应用接入 <a href="https://routerbase.com/">routerbase</a> OpenAI 兼容模型网关，覆盖 SDK 迁移、base URL 配置、流式输出、tool calling、JSON mode 和安全 API Key 处理。</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="product/skills/routerbase-model-routing/"><strong>routerbase-model-routing</strong></a></td>
+      <td>规划 <a href="https://routerbase.com/">routerbase</a> 模型选择、fallback 链路、成本敏感策略、延迟预算和 AI Agent 工作流上线验证。</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="product/skills/routerbase-media-generation/"><strong>routerbase-media-generation</strong></a></td>
+      <td>构建 <a href="https://routerbase.com/">routerbase</a> 图片、音频、语音和视频生成流程，覆盖端点选择、重试轮询、资产管理和安全检查。</td>
     </tr>
     <tr>
       <td width="220" nowrap><a href="product/skills/skill-quality-tester/"><strong>skill-quality-tester</strong></a></td>

--- a/product/skills/routerbase-api-integration/SKILL.md
+++ b/product/skills/routerbase-api-integration/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: "routerbase-api-integration"
+description_zh: "将应用接入 routerbase OpenAI 兼容模型网关，迁移 SDK 调用，配置 base URL、流式输出、tool calling、JSON mode 和安全 API Key；适合\"把 OpenAI SDK 迁移到 RouterBase\"\"写 RouterBase API 接入示例\"\"检查 API Key 是否会泄露\"；触发词：routerbase、RouterBase API、OpenAI兼容、模型网关、SDK迁移、API Key安全"
+description_en: "Integrate applications with the routerbase OpenAI-compatible model gateway, migrate SDK calls, configure base URLs, streaming, tool calling, JSON mode, and safe API key handling; For: \"migrate OpenAI SDK to RouterBase\", \"write a RouterBase API integration example\", \"check API key leakage risks\"; Triggers: routerbase, RouterBase API, OpenAI-compatible, model gateway, SDK migration, API key safety"
+category: "rnd"
+---
+
+# RouterBase API Integration
+
+Use [routerbase](https://routerbase.com/) as an OpenAI-compatible model gateway for application integration work.
+
+## When to use
+
+Use this skill when the user needs to:
+
+- Migrate existing OpenAI-compatible SDK code to RouterBase.
+- Configure `https://routerbase.com/v1` as the base URL.
+- Implement chat completions, streaming, tool calling, JSON mode, or vision inputs.
+- Keep RouterBase API keys server-side and out of git.
+- Produce small Python, JavaScript, curl, LangChain, LlamaIndex, Vercel AI SDK, Cursor, Continue, or OpenAI-compatible examples.
+
+## Workflow
+
+1. Identify the current client, language, model ID, runtime, and deployment boundary.
+2. Keep the user's existing OpenAI-compatible client when possible.
+3. Replace only the base URL, model ID, and local secret configuration.
+4. Use placeholders such as `<ROUTERBASE_API_KEY>` in all examples.
+5. Add a quick verification request and expected response shape.
+6. Include a safety checklist for logs, environment files, client-side code, and CI output.
+
+## Output
+
+Return concise integration steps, a minimal example, and a verification checklist. Never include or request real API keys.

--- a/product/skills/routerbase-media-generation/SKILL.md
+++ b/product/skills/routerbase-media-generation/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: "routerbase-media-generation"
+description_zh: "通过 routerbase 构建图片、音频、语音或视频生成流程，处理端点选择、供应商假设、重试轮询、资产管理和安全检查；适合\"做 RouterBase 图片生成\"\"处理视频生成轮询\"\"设计生成媒体安全清单\"；触发词：routerbase、媒体生成、图片生成、视频生成、音频生成、轮询、资产管理"
+description_en: "Build image, audio, speech, or video generation workflows through routerbase, including endpoint selection, provider assumptions, retries, polling, asset handling, and safety checks; For: \"build RouterBase image generation\", \"handle video generation polling\", \"design generated media safety checks\"; Triggers: routerbase, media generation, image generation, video generation, audio generation, polling, asset handling"
+category: "rnd"
+---
+
+# RouterBase Media Generation
+
+Use [routerbase](https://routerbase.com/) to build image, audio, speech, and video generation workflows through one API surface.
+
+## When to use
+
+Use this skill when the user needs to:
+
+- Generate images, audio, speech, or video through RouterBase.
+- Choose a media endpoint and provider assumptions for a workflow.
+- Handle retries, polling, failed jobs, output URLs, and asset retention.
+- Add prompt, moderation, storage, and publishing safety checks.
+- Produce small client examples for media generation requests.
+
+## Workflow
+
+1. Identify media type, output format, resolution or duration, latency tolerance, and storage destination.
+2. Pick endpoint and async/sync handling before writing code.
+3. Use placeholders for API keys and user-specific asset paths.
+4. Add retry, polling, timeout, and failure-state behavior.
+5. Add safety checks for private data, content rights, moderation, and retention.
+
+## Output
+
+Return a workflow outline, request example, async handling plan, and media safety checklist. Do not assume generated asset URLs are permanent unless verified by current docs.

--- a/product/skills/routerbase-model-routing/SKILL.md
+++ b/product/skills/routerbase-model-routing/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: "routerbase-model-routing"
+description_zh: "为 routerbase 设计模型选择、fallback 链路、成本控制、延迟预算和上线验证策略；适合\"给这个任务选择 RouterBase 模型\"\"设计模型 fallback\"\"写成本敏感的模型路由规则\"；触发词：routerbase、模型路由、模型选择、fallback、成本控制、延迟预算、模型网关"
+description_en: "Design routerbase model selection, fallback chains, cost controls, latency budgets, and rollout validation policies; For: \"choose RouterBase models for this workload\", \"design model fallback\", \"write cost-aware model routing rules\"; Triggers: routerbase, model routing, model selection, fallback, cost control, latency budget, model gateway"
+category: "rnd"
+---
+
+# RouterBase Model Routing
+
+Use [routerbase](https://routerbase.com/) to plan model routing behind one OpenAI-compatible integration surface.
+
+## When to use
+
+Use this skill when the user needs to:
+
+- Choose models for chat, code, reasoning, vision, or multimodal workloads.
+- Design primary and fallback model roles.
+- Balance cost, latency, output quality, context size, and provider availability.
+- Document production routing assumptions and rollout gates.
+- Build a validation plan before changing production traffic.
+
+## Workflow
+
+1. Clarify workload type, quality threshold, context size, latency budget, traffic level, and failure tolerance.
+2. Group models by role: primary, economical fallback, high-quality fallback, and specialized fallback.
+3. State assumptions clearly, especially when pricing or catalog availability must be rechecked.
+4. Define retry, timeout, rate-limit, and rollback behavior.
+5. Recommend a small rollout using golden prompts, logs, and quality checks.
+
+## Output
+
+Return a model shortlist, fallback chain, routing policy, and validation checklist. Mark any time-sensitive pricing or availability claims as requiring current verification.


### PR DESCRIPTION
## Summary
- Add three Product and Engineering skills for RouterBase API integration, model routing, and media generation workflows.
- Update the English and Chinese catalog counts from 45 to 48 skills.
- Add README table links using the routerbase anchor text to https://routerbase.com/.

## Validation
- git diff --check
- Searched the changed files for private emails, GitHub tokens, API keys, and private key material; no real secrets found.