### PR TITLE
Add Tree Ring Memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is a collection of high-quality Orkas agents and skills, continuous
 Orkas homepage: https://orkas.ai?source=github<br>
 Orkas open-source version: https://github.com/Orkas-AI/Orkas
 
-Current catalog: 26 agents and 45 skills.
+Current catalog: 26 agents and 46 skills.
 
 ## Category Overview
 
@@ -19,7 +19,7 @@ Current catalog: 26 agents and 45 skills.
 | [E-commerce](#e-commerce) | `ecommerce/` | 3 | 4 | Product listings, customer support, campaign planning, and store operations. |
 | [Product and Engineering](#product-and-engineering) | `product/` | 6 | 12 | PRDs, technical specs, user stories, release notes, and research workflows. |
 | [Creation](#creation) | `creation/` | 3 | 8 | Creative direction, drafting, editing, rewriting, visual concepting, and publishing workflows. |
-| [Data](#data) | `data/` | 4 | 6 | Data cleaning, spreadsheet analysis, SQL reasoning, metrics, and reports. |
+| [Data](#data) | `data/` | 4 | 7 | Data cleaning, knowledge management, spreadsheet analysis, SQL reasoning, metrics, and reports. |
 | [Office](#office) | `office/` | 4 | 7 | Documents, slides, meeting notes, email drafts, and daily productivity. |
 | [General](#general) | `general/` | 0 | 0 | Research, translation, planning, summarization, and general assistance. |
 
@@ -427,6 +427,10 @@ Current catalog: 26 agents and 45 skills.
     <tr>
       <td width="220" nowrap><a href="data/skills/material-organizer/"><strong>material-organizer</strong></a></td>
       <td>Organize user-provided URLs, PDFs, Word documents, images, text snippets, or local folders with extraction, source tracing, knowledge cards, entity links, deduplication, classification, exception logs, and keyword indexes; For: &quot;organize these links&quot;, &quot;turn these materials into research notes&quot;, &quot;extract knowledge cards from this&quot;, &quot;organize my Downloads folder&quot;; Triggers: material organization, research notes, knowledge cards, personal knowledge flow, entity links, keyword index, folder cleanup</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="data/skills/tree-ring-memory/"><strong>tree-ring-memory</strong></a></td>
+      <td>Use Tree Ring Memory for local-first AI agent memory lifecycle work: recall project memory before risky tasks, capture evidence-linked lessons, preserve scars, and manage privacy-safe remember, redact, audit, and forget workflows; For: &quot;remember this project decision&quot;, &quot;recall what we learned&quot;, &quot;redact or delete this memory&quot;; Triggers: Tree Ring Memory, agent memory, project memory, memory recall, evidence memory, redaction, forgetting, audit</td>
     </tr>
     <tr>
       <td width="220" nowrap><a href="data/skills/notion/"><strong>notion</strong></a></td>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 Orkas 主页：https://orkas.ai?source=github<br>
 Orkas 开源版本：https://github.com/Orkas-AI/Orkas
 
-当前目录包含：26 个 agent，45 个 skill。
+当前目录包含：26 个 agent，46 个 skill。
 
 ## 分类总览
 
@@ -19,7 +19,7 @@ Orkas 开源版本：https://github.com/Orkas-AI/Orkas
 | [电商](#电商) | `ecommerce/` | 3 | 4 | 商品详情、客服话术、活动策划、店铺运营等。 |
 | [产研](#产研) | `product/` | 6 | 12 | PRD、技术方案、用户故事、发布说明、需求研究等。 |
 | [创作](#创作) | `creation/` | 3 | 8 | 创意策划、起草、润色、改写、视觉构思、发布流程等。 |
-| [数据](#数据) | `data/` | 4 | 6 | 数据清洗、表格分析、SQL 推理、指标解读、数据报告等。 |
+| [数据](#数据) | `data/` | 4 | 7 | 数据清洗、知识管理、表格分析、SQL 推理、指标解读、数据报告等。 |
 | [办公](#办公) | `office/` | 4 | 7 | 文档、幻灯片、会议纪要、邮件草稿、日常效率等。 |
 | [通用](#通用) | `general/` | 0 | 0 | 检索、翻译、规划、总结、决策辅助等通用任务。 |
 
@@ -427,6 +427,10 @@ Orkas 开源版本：https://github.com/Orkas-AI/Orkas
     <tr>
       <td width="220" nowrap><a href="data/skills/material-organizer/"><strong>material-organizer</strong></a></td>
       <td>整理用户已提供的链接、PDF、Word、图片、文本片段或本地目录，做要点提取、来源溯源、知识卡沉淀、实体关系、去重归类、异常记录和关键词索引；适合&quot;整理这些链接&quot;&quot;把这些资料整理成研究笔记&quot;&quot;从这段内容提取知识卡&quot;&quot;帮我整理下载目录&quot;；触发词：资料整理、批量整理、研究笔记、知识卡、个人知识流、实体关系、关键词索引、目录整理</td>
+    </tr>
+    <tr>
+      <td width="220" nowrap><a href="data/skills/tree-ring-memory/"><strong>tree-ring-memory</strong></a></td>
+      <td>使用 Tree Ring Memory 做本地优先的 AI Agent 记忆生命周期管理：在高风险任务前检索项目记忆，记录有证据的经验，保留失败 scar，处理隐私安全的记录、脱敏、审计和遗忘；适合&quot;记住这个项目决策&quot;&quot;回忆之前怎么处理的&quot;&quot;删除或脱敏这条记忆&quot;；触发词：Tree Ring Memory、agent memory、项目记忆、记忆检索、证据记忆、脱敏、遗忘、审计</td>
     </tr>
     <tr>
       <td width="220" nowrap><a href="data/skills/notion/"><strong>notion</strong></a></td>

--- a/data/skills/tree-ring-memory/SKILL.md
+++ b/data/skills/tree-ring-memory/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: tree-ring-memory
+description_zh: "使用 Tree Ring Memory 做本地优先的 AI Agent 记忆生命周期管理：在高风险任务前检索项目记忆，记录有证据的经验，保留失败 scar，处理隐私安全的记录、脱敏、审计和遗忘；适合\"记住这个项目决策\"\"回忆之前怎么处理的\"\"删除或脱敏这条记忆\"；触发词：Tree Ring Memory、agent memory、项目记忆、记忆检索、证据记忆、脱敏、遗忘、审计"
+description_en: "Use Tree Ring Memory for local-first AI agent memory lifecycle work: recall project memory before risky tasks, capture evidence-linked lessons, preserve scars, and manage privacy-safe remember, redact, audit, and forget workflows; For: \"remember this project decision\", \"recall what we learned\", \"redact or delete this memory\"; Triggers: Tree Ring Memory, agent memory, project memory, memory recall, evidence memory, redaction, forgetting, audit"
+description: "Use Tree Ring Memory for local-first AI agent memory lifecycle work: recall before risky tasks, evidence-linked learning, privacy-safe capture, redaction, audit, and forgetting."
+category: "data"
+---
+
+# tree-ring-memory
+
+Use Tree Ring Memory when an agent needs durable project memory without turning
+chat history into a transcript dump. The skill is a workflow guide for recall,
+remembering, evidence capture, redaction, audit, consolidation, and forgetting.
+The canonical project ships a Rust `tree-ring` CLI backed by local SQLite/FTS
+storage.
+
+## When To Use
+
+- Before changing architecture, storage, security, privacy, release, or data behavior.
+- When a user correction, project decision, or validated lesson should survive the current session.
+- When a failed approach should stay visible as a reusable warning or scar.
+- When an agent needs project-scoped recall with source references.
+- When memory should be redacted, deleted, superseded, or audited instead of kept forever.
+
+Do not use for:
+
+- Storing secrets, credentials, tokens, raw chain-of-thought, or temporary scratchpad notes.
+- Treating memory as more authoritative than source files, tests, PRs, issues, or docs.
+- Writing unverifiable claims as durable project truth.
+- Uploading private memory to a remote service without explicit user instruction.
+
+## How To Call
+
+1. Read source truth first:
+   - Inspect the relevant repo files, docs, tests, issues, PRs, or run artifacts.
+   - Treat recalled memory as a pointer back to source evidence, not as a replacement.
+
+2. Recall narrowly:
+   - Query with project scope when possible.
+   - Prefer high-confidence, non-superseded results.
+   - Surface scars and warnings before repeating a risky workflow.
+
+3. Remember deliberately:
+   - Store concise lessons, decisions, user preferences, warnings, and future seeds.
+   - Use evidence-linked memory for tested outcomes, incidents, reviews, branches, and experiments.
+   - Include source references such as file paths, issue IDs, PR IDs, run IDs, or docs paths.
+
+4. Protect privacy:
+   - Redact sensitive details when the durable lesson is useful but exact content is unsafe.
+   - Delete memory when it should not be retained.
+   - Supersede stale memory when a newer decision replaces it.
+
+5. Close out meaningful work:
+   - Ask what was decided, what was learned, what should be avoided, and whether any future seed is worth keeping.
+   - Store only the parts that will materially improve future work.
+
+## CLI Reference
+
+Check the installed command surface before acting:
+
+```bash
+tree-ring --help
+tree-ring init
+tree-ring remember "Use project-scoped recall before changing release behavior." --event-type decision --scope project
+tree-ring recall "release behavior" --project example-service
+tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
+tree-ring audit --audit-type sensitive
+tree-ring consolidate --period-type manual --dry-run
+tree-ring maintain
+```
+
+Run broad workflows with dry-run modes first when available:
+
+```bash
+tree-ring import memories.jsonl --dry-run
+tree-ring dox sync --source-root . --dry-run
+tree-ring revolve sync --source-root revolve --dry-run
+tree-ring integrations scan --source-root .
+```
+
+If the current project has `.tree-ring/SKILL.md` or `.tree-ring/CLI.md`, read
+those files before issuing commands. A project-local install may require
+`--root .tree-ring`.
+
+## External Dependencies
+
+- Tree Ring Memory project: <https://github.com/TerminallyLazy/Tree-Ring-Memory>
+- Canonical skill package: <https://github.com/TerminallyLazy/Tree-Ring-Memory/tree/main/skills/tree-ring-memory>
+- The `tree-ring` CLI must be installed or available through the current project.
+
+## Limits And Known Issues
+
+- Memory is not source control, documentation, or test evidence.
+- Static recall cannot prove the remembered claim is still current; verify drift-prone facts.
+- Sensitive content should fail closed: redact, delete, or decline to store.
+- Dry-run audit and import outputs should be reviewed before applying changes.


### PR DESCRIPTION
## Summary
- add data/skills/tree-ring-memory/SKILL.md as a local-first agent memory lifecycle skill
- update English and Chinese catalog rows and skill counts
- frame Tree Ring Memory around recall before risky tasks, evidence-linked lessons, redaction, audit, and forgetting

## Validation
- checked for duplicate PRs and issues mentioning Tree Ring Memory
- verified the canonical Tree Ring skill URL returns HTTP 200
- validated frontmatter/catalog references locally
- ran git diff --check